### PR TITLE
Closes softlayer/sl-ember-test-helpers#59

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To see which issues are currently being worked on or are scheduled to be worked 
 
 # What is sl-ember-test-helpers
 
-This addon provides and registers QUnit test helpers for use in the testing of your application.
+This addon provides and registers test helpers for use in the testing of your application.  This addon is compatible with QUnit, Mocha, and any other testing framework you wish to use (or at least should be).
 
 
 ---
@@ -33,26 +33,28 @@ Emulates the beginning and completion of an AJAX request or requests.
 ### contains
 
 ```
-contains( valuesUnderTest, valuesToTestFor, 'Message passed to ok()' );
+contains( valuesUnderTest, valuesToTestFor );
 ```
 
-Test whether values are contained in other values.  These values can be a combination of Arrays, Strings, or Objects (for which the keys are extracted).  All *valuesToTestFor* must exist in *valuesUnderTest* for this test to pass successfully.
+Determine whether values are contained in other values.  These values can be a combination of Arrays, Strings, or Objects (for which the keys are extracted).  All *valuesToTestFor* must exist in *valuesUnderTest* for this determination to pass successfully.
 
-This test would fail because the Object being tested does not contain keys matching the values of "a" and "b":
+Calls to `contains()` return a boolean which can then be used in your tests.
 
-```
-contains( { c: 1, b: 3 }, [ 'a', 'b' ], 'Contains expected values' );
-```
-
-This test would pass because the Array being tested contains the value of "b":
+This call would fail because the Object being tested does not contain keys matching the values of "a" and "b":
 
 ```
-contains( [ 'a', 'b' ], 'b', 'Contains expected values' );
+contains( { c: 1, b: 3 }, [ 'a', 'b' ] );
+```
+
+This call would pass because the Array being tested contains the value of "b":
+
+```
+contains( [ 'a', 'b' ], 'b' );
 ```
 
 ### requires
 
-Use this helper to test that an argument passed to a function is of the required type(s).  The first argumens is the function under test and the second argument is an array of types to test for.
+Use this helper to test that an argument passed to a function is of the required type(s).  The first argument is the function under test and the second argument is an array of types to test for.
 
 ```
 requires( functionUnderTest, [ 'string', 'object', 'function' ] );
@@ -67,6 +69,15 @@ requires( functionUnderTest, [ 'string', 'object', 'function' ] );
 * function
 * undefined
 * boolean
+
+The call to `requires` returns an object:
+
+```
+{
+    requires: <boolean: true if functionUnderTest requires the provided arguments, false if not>
+    messages: <string: message per argument type that failed>
+}
+```
 
 
 ## Asynchronous

--- a/test-support/helpers/sl/synchronous/contains.js
+++ b/test-support/helpers/sl/synchronous/contains.js
@@ -16,17 +16,23 @@ import {
  * @param   {Ember.Application} app (optional)
  * @param   {array|string|object} underTest
  * @param   {mixed} testFor
- * @param   {string} message
- * @returns {void}
+ * @throws  {Ember.assert}
+ * @returns {boolean}
  */
 export default function() {
-    var index     = ( 3 === arguments.length ) ? 0 : 1,
+    var index     = ( 3 === arguments.length ) ? 1 : 0,
         underTest = arguments[index],
-        testFor   = arguments[index+1],
-        message   = arguments[index+2];
+        testFor   = arguments[index+1];
 
-    underTest = convertToArray( underTest );
-    testFor   = convertToArray( testFor );
+    Ember.assert(
+        'First non-optional argument must be an array, string or object',
+        'object' === typeof underTest || 'string' === typeof underTest || Array.isArray( underTest )
+    );
 
-    ok( doArraysIntersect( underTest, testFor ), message );
+    Ember.assert(
+        'Second non-optional argument must be an array, string or object',
+        'object' === typeof testFor || 'string' === typeof testFor || Array.isArray( testFor )
+    );
+
+    return doArraysIntersect( convertToArray( underTest ), convertToArray( testFor ) );
 }

--- a/test-support/helpers/sl/synchronous/requires.js
+++ b/test-support/helpers/sl/synchronous/requires.js
@@ -1,7 +1,12 @@
 import Ember from 'ember';
 
-// @TODO Return result of assertions rather than calling ok() - see https://github.com/softlayer/sl-ember-test-helpers/issues/59
-
+/**
+ * Test that an argument passed to a function is of the required type(s).
+ *
+ * @param  {function} methodUnderTest
+ * @param  {array}    requiredTypes
+ * @return {object}
+ */
 export default function( methodUnderTest, requiredTypes ) {
     var typesToTest = {
             'number' : {
@@ -32,7 +37,7 @@ export default function( methodUnderTest, requiredTypes ) {
             'undefined' : {
                 required  : false,
                 testValue : undefined,
-                message   : 'Parameter was empty'
+                message   : 'Parameter was undefined'
             },
             'boolean' : {
                 required  : false,
@@ -40,8 +45,9 @@ export default function( methodUnderTest, requiredTypes ) {
                 message   : 'Parameter was a boolean'
             }
         },
+        testsThatHaveFailed = [],
         assertionThrown,
-        assertionState,
+        assertionPassed,
         property,
         parameter;
 
@@ -70,9 +76,16 @@ export default function( methodUnderTest, requiredTypes ) {
                 assertionThrown = true;
             }
 
-            assertionState = ( parameter['required'] ) ? !assertionThrown : assertionThrown;
+            assertionPassed = ( parameter['required'] ) ? !assertionThrown : assertionThrown;
 
-            ok( assertionState, parameter['message'] );
+            if ( !assertionPassed ) {
+                testsThatHaveFailed.push( parameter['message'] );
+            }
         }
     }
+
+    return {
+        requires: ( 0 === testsThatHaveFailed.length ) ? true : false,
+        messages: testsThatHaveFailed.join( '; ' )
+    };
 }

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -23,7 +23,8 @@
     "currentURL",
     "currentPath",
     "currentRouteName",
-    "sinon"
+    "sinon",
+    "require"
   ],
   "node": false,
   "browser": false,

--- a/tests/unit/helpers/sl/synchronous/contains-test.js
+++ b/tests/unit/helpers/sl/synchronous/contains-test.js
@@ -4,32 +4,205 @@ import {
 
 import contains from '../../../../helpers/sl/synchronous/contains';
 
+var utils = require( 'dummy/tests/helpers/sl/utils/utils' );
+
 module( 'Unit - helpers:sl/synchronous/contains' );
 
 test( 'it exists', function( assert ) {
     assert.ok( contains, 'it exists' );
 });
 
-test( 'EMPTY TEST', function( assert ) {
-    assert.expect(0);
+test( 'First non-optional argument must be an array, string or object', function( assert ) {
 
-    /*
-    The reason this test is empty is because I have yet to find a good way to test the contains() helper.
+    // Number
+    var assertionThrown = false;
 
-    Conceptually, all that needs to be tested is whether or not contains() returns the correct boolean response when
-    provided two values to compare.  In reality, I'm torn on whether to be a little more specific in the testing,
-    ensuring that doArraysIntersect() is being called, and more importantly, with the arguments in the correct order.
-    These checks would be done with stubs, spies, etc.
+    try {
+        contains( 12 );
+    } catch( error ) {
+        assertionThrown = true;
+    }
 
-    Even without this more robust testing, the real problem is how to correctly test the call to ok() within contains().
-    I've taken a few stabs at it and never got it quite right.  One workaround would be to just have contains() return
-    a boolean and then use that within your tests in an ok() or other call.  This would solve the testing problem but
-    my intention for this helper was not to serve as a utility class to return a boolean, but to actually be an assertion
-    just like ok(), equals(), and others.
+    assert.ok( assertionThrown, 'First parameter was a number' );
 
-    That specific syntax of course locks the use of this addon into QUnit (as does the use of the message parameter),
-    rather than being flexible and allowing use with other test adapters such as Mocha.  So either the testing suite
-    being used for the application needs to be detected when the generator is ran and the correct syntax injected or it
-    should be more of utility function.  This all of course assume default configuration of the testing suites.
-     */
+    // String
+    assertionThrown = false;
+
+    try {
+        contains( 'testString', {} );
+    } catch( error ) {
+        assertionThrown = true;
+    }
+
+    assert.ok( !assertionThrown, 'First parameter was a string' );
+
+    // Array
+    assertionThrown = false;
+
+    try {
+        contains( [], {} );
+    } catch( error ) {
+        assertionThrown = true;
+    }
+
+    assert.ok( !assertionThrown, 'First parameter was an array' );
+
+    // Object
+    assertionThrown = false;
+
+    try {
+        contains( {}, {} );
+    } catch( error ) {
+        assertionThrown = true;
+    }
+
+    assert.ok( !assertionThrown, 'First parameter was an object' );
+
+    // Function
+    assertionThrown = false;
+
+    try {
+        contains( function(){} );
+    } catch( error ) {
+        assertionThrown = true;
+    }
+
+    assert.ok( assertionThrown, 'First parameter was a function' );
+
+    // Undefined
+    assertionThrown = false;
+
+    try {
+        contains( undefined );
+    } catch( error ) {
+        assertionThrown = true;
+    }
+
+    assert.ok( assertionThrown, 'First parameter was undefined' );
+
+    // Boolean
+    assertionThrown = false;
+
+    try {
+        contains( true );
+    } catch( error ) {
+        assertionThrown = true;
+    }
+
+    assert.ok( assertionThrown, 'First parameter was a boolean' );
+
+});
+
+test( 'Second non-optional argument must be an array, string or object', function( assert ) {
+
+    // Number
+    var assertionThrown = false;
+
+    try {
+        contains( {}, 12 );
+    } catch( error ) {
+        assertionThrown = true;
+    }
+
+    assert.ok( assertionThrown, 'Second parameter was a number' );
+
+    // String
+    assertionThrown = false;
+
+    try {
+        contains( {}, 'testString' );
+    } catch( error ) {
+        assertionThrown = true;
+    }
+
+    assert.ok( !assertionThrown, 'Second parameter was a string' );
+
+    // Array
+    assertionThrown = false;
+
+    try {
+        contains( {}, [] );
+    } catch( error ) {
+        assertionThrown = true;
+    }
+
+    assert.ok( !assertionThrown, 'Second parameter was an array' );
+
+    // Object
+    assertionThrown = false;
+
+    try {
+        contains( {}, {} );
+    } catch( error ) {
+        assertionThrown = true;
+    }
+
+    assert.ok( !assertionThrown, 'Second parameter was an object' );
+
+    // Function
+    assertionThrown = false;
+
+    try {
+        contains( {}, function(){} );
+    } catch( error ) {
+        assertionThrown = true;
+    }
+
+    assert.ok( assertionThrown, 'Second parameter was a function' );
+
+    // Undefined
+    assertionThrown = false;
+
+    try {
+        contains( {}, undefined );
+    } catch( error ) {
+        assertionThrown = true;
+    }
+
+    assert.ok( assertionThrown, 'Second parameter was undefined' );
+
+    // Boolean
+    assertionThrown = false;
+
+    try {
+        contains( {}, true );
+    } catch( error ) {
+        assertionThrown = true;
+    }
+
+    assert.ok( assertionThrown, 'Second parameter was a boolean' );
+
+});
+
+test( 'Returns value from call to doArraysIntersect()', function( assert ) {
+    var spy = sinon.spy( utils, 'doArraysIntersect' );
+
+    contains( [], [] );
+
+    assert.ok( spy.calledOnce, 'doArraysIntersect() was called' );
+
+    utils.doArraysIntersect.restore();
+});
+
+test( 'Arguments are passed to doArraysIntersect() in the correct order', function( assert ) {
+    var spy = sinon.spy( utils, 'doArraysIntersect' );
+
+    contains( 'b', [ 'd', 'e' ] );
+
+    assert.equal( spy.args[0][0], 'b', 'First argument' );
+    assert.deepEqual( spy.args[0][1], [ 'd', 'e' ], 'Second argument' );
+
+    utils.doArraysIntersect.restore();
+});
+
+test( 'Returns a boolean', function( assert ) {
+    var response;
+
+    response = contains( 'b', [ 'd', 'e' ] );
+
+    assert.propEqual( response, false, 'Is boolean false' );
+
+    response = contains( [ 'd', 'e' ], 'e' );
+
+    assert.propEqual( response, true, 'Is boolean true' );
 });

--- a/tests/unit/helpers/sl/synchronous/requires-test.js
+++ b/tests/unit/helpers/sl/synchronous/requires-test.js
@@ -170,18 +170,24 @@ test( 'Second argument must be an array', function( assert ) {
 
 });
 
-// @TODO Needs better test support.  See https://github.com/softlayer/sl-ember-test-helpers/issues/59
+test( 'Return type', function( assert ) {
+    var testFunction = function( first ) {
+        Ember.assert( 'Test argument must be a function or boolean', 'function' === typeof first || 'boolean' === typeof first );
+    },
+    test = requires( testFunction, [ 'function', 'boolean' ] );
+
+    assert.deepEqual( test, { requires: true, messages: '' }, 'Returns expected object' );
+});
+
 test( 'Functions as expected', function( assert ) {
     var testFunction = function( first ) {
-        Ember.assert( 'Test argument must be a function', 'function' === typeof first || 'boolean' === typeof first );
+        Ember.assert( 'Test argument must be a function or boolean', 'function' === typeof first || 'boolean' === typeof first );
     },
-    assertionThrown  = false;
+    test;
 
-    try {
-        requires( testFunction, [ 'function', 'boolean' ] );
-    } catch( error ) {
-        assertionThrown = true;
-    }
+    test = requires( testFunction, [ 'function', 'boolean' ] );
+    assert.ok ( test.requires, 'Functioned as expected when passed desired argument types: ' + test.messages );
 
-    assert.ok( !assertionThrown, 'Functioned as expected when passed desired argument types' );
+    test = requires( testFunction, [ 'function', 'boolean', 'string' ] );
+    assert.ok ( !test.requires, 'Functioned as expected when passed undesired argument types: ' + test.messages );
 });

--- a/tests/unit/helpers/sl/utils/utils-test.js
+++ b/tests/unit/helpers/sl/utils/utils-test.js
@@ -30,7 +30,9 @@ test( 'doArraysIntersect() exists', function( assert ) {
 });
 
 test( 'convertToArray() requires either an Array, String, or Object to be provided', function( assert ) {
-    requires( convertToArray, [ 'array', 'string', 'object' ] );
+    var test = requires( convertToArray, [ 'array', 'string', 'object' ] );
+
+    assert.ok ( test.requires, test.messages );
 });
 
 test( 'convertToArray() returns expected result', function( assert ) {
@@ -49,7 +51,9 @@ test( 'convertToArray() returns expected result', function( assert ) {
 });
 
 test( 'convertStringToArray() requires a string to be provided', function( assert ) {
-    requires( convertStringToArray, [ 'string' ] );
+    var test = requires( convertStringToArray, [ 'string' ] );
+
+    assert.ok ( test.requires, test.messages );
 });
 
 test( 'convertStringToArray() returns an array with a single element when passed a string without spaces', function( assert ) {
@@ -61,7 +65,9 @@ test( 'convertStringToArray() returns an array with as many elements as there ar
 });
 
 test( 'convertObjectKeysToArray() requires an object to be provided', function( assert ) {
-    requires( convertObjectKeysToArray, [ 'object' ] );
+    var test = requires( convertObjectKeysToArray, [ 'object' ] );
+
+    assert.ok ( test.requires, test.messages );
 });
 
 test( 'convertObjectKeysToArray() returns an array of object properties', function( assert ) {


### PR DESCRIPTION
* requires() and contains() no longer call ok() themselves but instead return a boolean to be used within the test itself.  This addresses issues of "assert" (QUnit 2.x) not being made available to the helpers without passing it in as well as being specifically tied to QUnit as the testing framework.

* Changed the index offset for contains() when being ran synchronously vs asynchronously