### PR TITLE
requires() helper should support null #106

### DIFF
--- a/test-support/helpers/sl/synchronous/requires.js
+++ b/test-support/helpers/sl/synchronous/requires.js
@@ -48,6 +48,11 @@ let requiresHelper = function( methodUnderTest, requiredTypes ) {
             required: false,
             testValue: true,
             message: 'Parameter was a boolean'
+        },
+        'null': {
+            required: false,
+            testValue: null,
+            message: 'Parameter was null'
         }
     };
 

--- a/tests/unit/helpers/sl/synchronous/requires-test.js
+++ b/tests/unit/helpers/sl/synchronous/requires-test.js
@@ -132,6 +132,23 @@ test( 'First argument must be a function', function( assert ) {
         'First parameter was a boolean'
     );
 
+    // Null
+    assertionThrown = false;
+
+    try {
+        requires(
+            null,
+            false
+        );
+    } catch( error ) {
+        assertionThrown = true;
+    }
+
+    assert.ok(
+        assertionThrown,
+        'First parameter was null'
+    );
+
 });
 
 test( 'Second argument must be an array', function( assert ) {
@@ -253,6 +270,23 @@ test( 'Second argument must be an array', function( assert ) {
     assert.ok(
         assertionThrown,
         'Second parameter was a boolean'
+    );
+
+    // Null
+    assertionThrown = false;
+
+    try {
+        requires(
+            null,
+            null
+        );
+    } catch( error ) {
+        assertionThrown = true;
+    }
+
+    assert.ok(
+        assertionThrown,
+        'Second parameter was null'
     );
 
 });


### PR DESCRIPTION
those tests in that format are a placeholder, refactoring for all tests in all test files coming soon and addressed in its own separate issue, https://huboard.com/softlayer/sl-ember-test-helpers#/issues/96823481