### PR TITLE
Closes softlayer/sl-ember-test-helpers#127

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,5 @@
     "qunit": "~1.17.1",
     "sinonjs": "~1.14.1"
   },
-  "devDependencies": {
-    "sinon-qunit": "~2.0.0"
-  }
+  "devDependencies": {}
 }

--- a/bower.json
+++ b/bower.json
@@ -10,10 +10,10 @@
     "ember-resolver": "~0.1.18",
     "jquery": "^1.11.1",
     "loader.js": "ember-cli/loader.js#3.2.0",
-    "qunit": "~1.17.1"
+    "qunit": "~1.17.1",
+    "sinonjs": "~1.14.1"
   },
   "devDependencies": {
-    "sinonjs": "~1.10.2",
     "sinon-qunit": "~2.0.0"
   }
 }

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -16,10 +16,6 @@ module.exports = function( defaults ) {
     */
 
     // Testing dependencies
-    app.import( app.bowerDirectory + '/sinonjs/sinon.js', {
-        type: 'test'
-    });
-
     app.import( app.bowerDirectory + '/sinon-qunit/lib/sinon-qunit.js', {
         type: 'test'
     });

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -15,11 +15,6 @@ module.exports = function( defaults ) {
     behave. You most likely want to be modifying `./index.js` or app's build file
     */
 
-    // Testing dependencies
-    app.import( app.bowerDirectory + '/sinon-qunit/lib/sinon-qunit.js', {
-        type: 'test'
-    });
-
     const tree = replace( app.toTree(), {
         files: [
             'index.html',

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.3",
+    "ember-sinon": "^0.2.1",
     "ember-try": "0.0.6",
     "sl-eslint": "0.1.2"
   }

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -23,7 +23,6 @@
     "currentURL",
     "currentPath",
     "currentRouteName",
-    "sinon",
     "require"
   ],
   "node": false,

--- a/tests/unit/helpers/sl/synchronous/ajax-test.js
+++ b/tests/unit/helpers/sl/synchronous/ajax-test.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import { test } from 'ember-qunit';
 import AjaxHelper from '../../../../helpers/sl/synchronous/ajax';
+import sinon from 'sinon';
 
 module( 'Unit | Helper | sl/synchronous/ajax' );
 
@@ -12,7 +13,7 @@ test( 'it exists', function( assert ) {
 });
 
 test( 'begin() with no parameter triggers "ajaxStart" event on document', function( assert ) {
-    const spy = window.sinon.spy( Ember.$.prototype, 'trigger' );
+    const spy = sinon.spy( Ember.$.prototype, 'trigger' );
 
     AjaxHelper.begin();
 
@@ -25,7 +26,7 @@ test( 'begin() with no parameter triggers "ajaxStart" event on document', functi
 });
 
 test( 'begin() with parameter triggers "ajaxSend" event on document', function( assert ) {
-    const spy = window.sinon.spy( Ember.$.prototype, 'trigger' );
+    const spy = sinon.spy( Ember.$.prototype, 'trigger' );
 
     AjaxHelper.begin( 'testEndpoint' );
 
@@ -42,7 +43,7 @@ test( 'begin() with parameter triggers "ajaxSend" event on document', function( 
 });
 
 test( 'end() with no parameter triggers "ajaxStop" event on document', function( assert ) {
-    const spy = window.sinon.spy( Ember.$.prototype, 'trigger' );
+    const spy = sinon.spy( Ember.$.prototype, 'trigger' );
 
     AjaxHelper.end();
 
@@ -55,7 +56,7 @@ test( 'end() with no parameter triggers "ajaxStop" event on document', function(
 });
 
 test( 'end() with parameter triggers "ajaxComplete" event on document', function( assert ) {
-    const spy = window.sinon.spy( Ember.$.prototype, 'trigger' );
+    const spy = sinon.spy( Ember.$.prototype, 'trigger' );
 
     AjaxHelper.end( 'testEndpoint' );
 


### PR DESCRIPTION
- Updated uses of sinon to use imported sinon (from ember-simon)
- Removed existing sinon.js bower package
- Installed ember-sinon npm package
- Removed app-import of sinon.js in the ember-cli-build file
- Removed sinon-qunit bower package since it was not being used
- Removed app-importof sinon-quint in the ember-cli-build file