### PR TITLE
Removed unused called variable

### DIFF
--- a/test-support/helpers/sl/synchronous/global-libraries.js
+++ b/test-support/helpers/sl/synchronous/global-libraries.js
@@ -1,7 +1,6 @@
 import Ember from 'ember';
 import sinon from 'sinon';
 
-export let called;
 export let jqueryAliasSpy;
 export let jquerySpy;
 export let emberJquerySpy;


### PR DESCRIPTION
`called()` should be exported as a function and not a variable.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/softlayer/sl-ember-test-helpers/166)
<!-- Reviewable:end -->
